### PR TITLE
30 make the db scripts continue on errors

### DIFF
--- a/api/trip/tripModel.js
+++ b/api/trip/tripModel.js
@@ -14,5 +14,6 @@ let TripSchema = new Schema(
         type: {type: mongoose.Schema.Types.String, enum: ["BACK", "FORTH"], required: true}
     }
 );
+TripSchema.index({date:1, driver:1}, { unique: true });
 
 module.exports = mongoose.model('Trips', TripSchema);

--- a/scripts/createTestRecords.js
+++ b/scripts/createTestRecords.js
@@ -16,23 +16,24 @@ let passwordUtils = require("../api/utils/password"),
 
 
 console.log("This script populates the database with a few test records. (users and trips)." +
-    " It will fail if the DB is already filled with test records or not accessible. \n");
+    " It will fail if the DB is not accessible and log if a record is already present. \n");
 
 
 let createTestUsers = (callback) => {
     console.log("\nCreating test users.");
 
     async.parallel(
-        scriptsUtils.testUsers.map(
-            user =>
-                (cb) => new User({
-                    username: user[0],
-                    email: user[1],
-                    password: passwordUtils.cryptPasswordSync(user[2]),
-                    activated: user[3]
-                }).save(getSaveCallBack("User", cb, "username"))
-        ), callback
-    );
+        async.reflectAll(
+            scriptsUtils.testUsers.map(
+                user =>
+                    (cb) => new User({
+                        username: user[0],
+                        email: user[1],
+                        password: passwordUtils.cryptPasswordSync(user[2]),
+                        activated: user[3]
+                    }).save(getSaveCallBack("User", cb, "username"))
+            )), callback
+        );
 };
 
 const createTestTrips = (callback) => {
@@ -41,22 +42,23 @@ const createTestTrips = (callback) => {
     async.waterfall([
             (cb) => User.find({username: {$in: scriptsUtils.testUsers.map((user) => user[0])}}, cb),
             (users, cb) => async.parallel(
-                scriptsUtils.testTrips.map(
-                    (trip, index) => (
-                        (cb) => new Trip({
-                            date: trip[0],
-                            driver: users[index],
-                            passengers: [users[index], users[index + 1]],
-                            location: trip[1],
-                            seats: trip[2],
-                            type: trip[3]
-                        }).save(getSaveCallBack("Trip", cb, serializeTrip))
-                    )
-                ), cb)
+                async.reflectAll(
+                    scriptsUtils.testTrips.map(
+                        (trip, index) => (
+                            (cb) => new Trip({
+                                date: trip[0],
+                                driver: users[index],
+                                passengers: [users[index], users[index + 1]],
+                                location: trip[1],
+                                seats: trip[2],
+                                type: trip[3]
+                            }).save(getSaveCallBack("Trip", cb, serializeTrip))
+                        )
+                    )), cb)
         ],
         callback
     )
 
 };
 
-async.series([createTestUsers, createTestTrips], mainCallback);
+async.series(async.reflectAll([createTestUsers, createTestTrips]), mainCallback);

--- a/scripts/initDB.js
+++ b/scripts/initDB.js
@@ -15,7 +15,7 @@ let scriptsUtils = require("./scriptsUtils"),
     mainCallback = scriptsUtils.getMainCallback(mongooseConnection);
 
 console.log("This script populates initial necessary objects to the database (rooms & editions)." +
-            " It will fail if the DB is already filled or not accessible. \n");
+    " It will fail if the DB is not accessible and log if a record is already present. \n");
 
 let createRooms = (callback) => {
     let stackCreateRooms = [];
@@ -25,25 +25,31 @@ let createRooms = (callback) => {
         (floor) => {
             floor.rooms.forEach((room) =>
                 stackCreateRooms.push(
-                    (cb) => new Room({type: room.type, text: room.name, nbBeds: room.seats}).save(getSaveCallBack("Room", cb, "text"))
+                    (cb) => new Room({
+                        type: room.type,
+                        text: room.name,
+                        nbBeds: room.seats
+                    }).save(getSaveCallBack("Room", cb, "text"))
                 )
-            )
+            );
         }
     );
     // And then they're executed in parallel
-    async.parallel(stackCreateRooms, callback);
+    async.parallel(async.reflectAll(stackCreateRooms), callback);
 };
 
 let createEditions = (callback) => {
     async.parallel(
-        editions.editions.map(editionDef =>
-            (cb) => new Edition({
-                year: editionDef.year,
-                weekendDate: editionDef.weekendDate,
-                shotgunDate: editionDef.shotgunDate
-            }).save(getSaveCallBack("Edition", cb, "year"))
+        async.reflectAll(
+            editions.editions.map(editionDef =>
+                (cb) => new Edition({
+                    year: editionDef.year,
+                    weekendDate: editionDef.weekendDate,
+                    shotgunDate: editionDef.shotgunDate
+                }).save(getSaveCallBack("Edition", cb, "year"))
+            )
         ), callback);
 };
 
 
-async.parallel([createRooms, createEditions], mainCallback);
+async.parallel(async.reflectAll([createRooms, createEditions]), mainCallback);

--- a/scripts/scriptsUtils.js
+++ b/scripts/scriptsUtils.js
@@ -11,6 +11,7 @@ const getDeleteMessage = (schemaName, objStr) => `${schemaName} removed from the
 const getSingleOperationCallback = (label, callback, objectSerialize, messageFct) =>
     (err, object) => {
         if (err) {
+            console.log(err.errmsg);
             callback(err, null);
             return
         }
@@ -34,7 +35,7 @@ module.exports = {
             if (process.env.MONGO_CONNECTION === undefined)
                 throw "ERROR: In a prod environment (NODE_ENV=production) you need to set MONGO_CONNECTION";
 
-            return process.env.MONGO_CONNECTION
+            return process.env.MONGO_CONNECTION;
         }
         // Get arguments passed on command line
         let userArgs = process.argv.slice(2);
@@ -60,8 +61,9 @@ module.exports = {
     getDeleteManyCallback: (label, callback) =>
         (err, result) => {
             if (err) {
+                console.log(err.errmsg);
                 callback(err, null);
-                return
+                return;
             }
             console.log(`${label} have been deleted if present, ${result.n} actual deletions.`);
             callback(null);

--- a/scripts/scriptsUtils.js
+++ b/scripts/scriptsUtils.js
@@ -88,7 +88,7 @@ module.exports = {
         ["Claire", "claire", "test", true]
     ],
     testTrips: [
-        [new Date(), "Paris 18", 3, "BACK"],
+        [Date.parse('09 Jun 2020 15:45:00 GMT'), "Paris 18", 3, "BACK"],
         [Date.parse('01 Jan 1970 00:45:00 GMT'), "Paris 18", 4, "BACK"],
         [Date.parse('28 Jan 1979 15:30:00 GMT'), "Montélimart", 1, "FORTH"],
         [Date.parse('05 Jan 1970 00:00:00 GMT'), "Châlons-sur-Saone", 6, "BACK"],


### PR DESCRIPTION
# Goal
Have all the db scripts continues regardless of errors on the way
# Modifications
- Adding an index for uniqueness of date/driver on trips
- Adding reflectAll to the async flows where it was needed in the db scripts
- Updating messages alongside the db scripts
- Console logging errors
- Removing the current date test trip to make it fixed